### PR TITLE
build: nodejs on codebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   "packageManager": "pnpm@9.4.0",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=8"
+    "pnpm": ">=9"
   }
 }

--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -9,7 +9,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 18.x
+      nodejs: 20.x
     commands:
       - wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
       - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list

--- a/pipelines/production.yml
+++ b/pipelines/production.yml
@@ -14,7 +14,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 18.x
+      nodejs: 20.x
     commands:
       - wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
       - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list

--- a/pipelines/stage.yml
+++ b/pipelines/stage.yml
@@ -14,7 +14,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 18.x
+      nodejs: 20.x
     commands:
       - wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
       - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list


### PR DESCRIPTION
Bump version of Nodejs used in AWS CodeBuild to match GitHub Actions and local development